### PR TITLE
Feature: Add instructor tagline to admin posts

### DIFF
--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/topic/post.tpl
@@ -44,6 +44,7 @@
 					</div>
 
 					<a class="fw-bold text-nowrap text-truncate" href="{{{ if ./user.userslug }}}{config.relative_path}/user/{./user.userslug}{{{ else }}}#{{{ end }}}" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+                    
 				</div>
 
 				{{{ each posts.user.selectedGroups }}}


### PR DESCRIPTION
## Summary
This PR introduces UI change to include a tag on posts made by admin accounts (Instructors and TAs)

## Changes                    

-  `src/posts/user.js` 
    populated `user.posts.isAdmin` to check if poster is admin or not for template display
- `src/views/partials/topic/post-preview.tpl`, etc.
modified templates in different locations across site to include the instructor tagline

## Verification
- Verified that only Admin users have tags in their posts
- Verified that instructor tags are visible to all users
- Verified that admin privileges are not being modified for users just a flag in front-end if a post was made by an admin

## UI Testing
[Watch Demo](https://drive.google.com/file/d/1-FOFU3xHnaumPcdSZ9T_w1cdBrExuJ-S/view?usp=sharing)